### PR TITLE
Add github action build and test with docker.

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -42,7 +42,20 @@ jobs:
         run: docker exec builder make tidy
       - name: make build
         run: docker exec builder make build
-      # - name: git diff --exit-code
-      #   run: docker exec builder git diff --exit-code
       - name: make test
         run: docker exec builder make test
+      - name: git diff --exit-code
+        run: docker cp builder:/app ./post-build && git -C post-build diff --exit-code
+      - name: Stop container
+        if: ${{ always() }}
+        run: docker stop builder
+      - name: Remove container
+        if: ${{ always() }}
+        run: docker rm builder
+  swagger-codegen-cli:
+    runs-on: ubuntu-latest
+    container: swaggerapi/swagger-codegen-cli
+    steps:
+      - uses: actions/checkout@v2
+      - name: run the main swagger.yml validation
+        run: java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar validate -i ./api/swagger.yml

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,48 @@
+name: Build & Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+env:
+  DOCKER_ENV_FILE: ".github/workflows/docker.env"
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:12.2-alpine
+        env:
+          POSTGRES_DB: "development"
+          POSTGRES_USER: "dbuser"
+          POSTGRES_PASSWORD: "dbpass"
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      integresql:
+        image: allaboutapps/integresql:latest
+        env:
+          PGHOST: "postgres"
+          PGUSER: "dbuser"
+          PGPASSWORD: "dbpass"
+      mailhog:
+        image: mailhog/mailhog
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the Docker image
+        run: docker build --target builder --file Dockerfile --tag allaboutapps/go-starter:${GITHUB_SHA:8} .
+      - name: Create container
+        run: docker run -d --env-file $DOCKER_ENV_FILE --network "${{ job.services.postgres.network }}" --name=builder -it allaboutapps/go-starter:${GITHUB_SHA:8}
+      - name: make tidy
+        run: docker exec builder make tidy
+      - name: make build
+        run: docker exec builder make build
+      # - name: git diff --exit-code
+      #   run: docker exec builder git diff --exit-code
+      - name: make test
+        run: docker exec builder make test

--- a/.github/workflows/docker.env
+++ b/.github/workflows/docker.env
@@ -1,0 +1,22 @@
+CI=true
+GITHUB_ACTIONS=true
+# required: env for main working database, service
+# default for sql-migrate (target development) and psql cli tool
+PGDATABASE=development
+PGUSER=dbuser
+PGPASSWORD=dbpass
+PGHOST=postgres
+PGPORT=5432
+PGSSLMODE=disable
+
+# optional: env for sql-boiler (ability to generate models out of a "spec" database)
+# sql-boiler should operate on a "spec" database only
+PSQL_DBNAME=spec
+PSQL_USER=dbuser
+PSQL_PASS=dbpass
+PSQL_HOST=postgres
+PSQL_PORT=5432
+PSQL_SSLMODE=disable
+
+# optional: project root directory, used for relative path resolution (e.g. fixtures)
+PROJECT_ROOT_DIR=/app


### PR DESCRIPTION
Using a few workarounds to build inside a docker container.

Using `docker run` to use the build image without pushing and pulling from a registry. Therefore using an extra env file for the environment variables in comparison to using a separate job with a specified container. This is also the reason of doing every step inside one single job.

See: https://github.community/t/whats-the-recommended-way-to-pass-a-docker-image-to-the-next-job-in-a-workflow/17225