### PR TITLE
Golang v1.17.1 buster

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  # also lint files within /scripts. Those have "// +build scripts" set.
+  # also lint files within /scripts. Those have "//go:build scripts" set.
   build-tags:
     - scripts
 linters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 
 ### Changed
 
-- **Hotfix**: We will pin the `Dockerfile` development and builder stage to `golang:1.16.7-buster` (+ `-buster`) for now, as currently the [new debian bullseye release within the go official docker images](https://github.com/docker-library/golang/commit/48a7371ed6055a97a10adb0b75756192ad5f1c97) breaks some tooling. The upgrade to debian bullseye and Go 1.17 will happen simultaneously within go-starter in the following weeks. 
+- **Hotfix**: We will pin the `Dockerfile` development and builder stage to `golang:1.16.7-buster` (+ `-buster`) for now, as currently the [new debian bullseye release within the go official docker images](https://github.com/docker-library/golang/commit/48a7371ed6055a97a10adb0b75756192ad5f1c97) breaks some tooling. The upgrade to debian bullseye and Go 1.17 will happen ~simultaneously~ **separately** within go-starter in the following weeks. 
 
 ## 2021-08-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 ### Changed
 
+- **BREAKING** Upgrades to [Go 1.17.1](https://golang.org/doc/go1.17) `golang:1.17.1-buster`
+  - Switch to `//go:build <tag>` from `// +build <tag>`.
+  - Migrates `go.mod` via `go mod tidy -go=1.17` (pruned module graphs).
 - Upgrades [golangci-lint](https://github.com/golangci/golangci-lint) from `v1.41.1` to [`v1.42.1`](https://github.com/golangci/golangci-lint/releases/tag/v1.42.1) (for reference [`v1.42.0`](https://github.com/golangci/golangci-lint/releases/tag/v1.42.0)).
 - Bump github.com/go-openapi/strfmt from [0.20.1 to 0.20.2](https://github.com/go-openapi/strfmt/compare/v0.20.1...v0.20.2)
 - Bump github.com/go-openapi/errors from [0.20.0 to 0.20.1](https://github.com/go-openapi/errors/compare/v0.20.0...v0.20.1)

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,9 @@ check-gen-dirs: ##- (opt) Ensures internal/models|types only hold generated file
 	@grep -R -L '^// Code generated .* DO NOT EDIT\.$$' --exclude ".DS_Store" ./internal/types/ && echo "Error: Non generated file(s) in ./internal/types!" && exit 1 || exit 0
 	@grep -R -L '^// Code generated .* DO NOT EDIT\.$$' --exclude ".DS_Store" ./internal/models/ && echo "Error: Non generated file(s) in ./internal/models!" && && exit 1 || exit 0
 
-check-script-dir: ##- (opt) Ensures all scripts/**/*.go files have the "// +build scripts" build tag set.
+check-script-dir: ##- (opt) Ensures all scripts/**/*.go files have the "//go:build scripts" build tag set.
 	@echo "make check-script-dir"
-	@grep -R --include=*.go -L '// +build scripts' ./scripts && echo "Error: Found unset '// +build scripts' in ./scripts/**/*.go!" && exit 1 || exit 0
+	@grep -R --include=*.go -L '//go:build scripts' ./scripts && echo "Error: Found unset '//go:build scripts' in ./scripts/**/*.go!" && exit 1 || exit 0
 
 # https://github.com/gotestyourself/gotestsum#format 
 # w/o cache https://github.com/golang/go/issues/24573 - see "go help testflag"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module allaboutapps.dev/aw/go-starter
 
-go 1.16
+go 1.17
 
 require (
 	github.com/allaboutapps/integresql-client-go v1.0.0
@@ -29,8 +29,87 @@ require (
 	github.com/volatiletech/randomize v0.0.1
 	github.com/volatiletech/sqlboiler/v4 v4.6.0
 	github.com/volatiletech/strmangle v0.0.1
-	github.com/ziutek/mymysql v1.5.4 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519
 	golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6
 	google.golang.org/api v0.57.0
+)
+
+require (
+	cloud.google.com/go v0.94.1 // indirect
+	github.com/Masterminds/goutils v1.1.0 // indirect
+	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/armon/go-radix v1.0.0 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect
+	github.com/bgentry/speakeasy v0.1.0 // indirect
+	github.com/denisenkom/go-mssqldb v0.10.0 // indirect
+	github.com/ericlagergren/decimal v0.0.0-20181231230500-73749d4874d5 // indirect
+	github.com/fatih/color v1.9.0 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-logfmt/logfmt v0.5.0 // indirect
+	github.com/go-openapi/analysis v0.20.0 // indirect
+	github.com/go-openapi/jsonpointer v0.19.5 // indirect
+	github.com/go-openapi/jsonreference v0.19.5 // indirect
+	github.com/go-openapi/loads v0.20.2 // indirect
+	github.com/go-openapi/spec v0.20.3 // indirect
+	github.com/go-sql-driver/mysql v1.5.0 // indirect
+	github.com/go-stack/stack v1.8.0 // indirect
+	github.com/godror/godror v0.24.2 // indirect
+	github.com/gofrs/uuid v3.2.0+incompatible // indirect
+	github.com/golang-jwt/jwt v3.2.2+incompatible // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/uuid v1.1.2 // indirect
+	github.com/googleapis/gax-go/v2 v2.1.0 // indirect
+	github.com/hashicorp/errwrap v1.0.0 // indirect
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/imdario/mergo v0.3.11 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/labstack/gommon v0.3.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-oci8 v0.1.1 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mattn/go-sqlite3 v1.14.6 // indirect
+	github.com/mitchellh/cli v1.1.2 // indirect
+	github.com/mitchellh/copystructure v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.2 // indirect
+	github.com/mitchellh/reflectwalk v1.0.0 // indirect
+	github.com/oklog/ulid v1.3.1 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/posener/complete v1.2.3 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/valyala/bytebufferpool v1.0.0 // indirect
+	github.com/valyala/fasttemplate v1.2.1 // indirect
+	github.com/volatiletech/inflect v0.0.1 // indirect
+	github.com/ziutek/mymysql v1.5.4 // indirect
+	go.mongodb.org/mongo-driver v1.5.1 // indirect
+	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/net v0.0.0-20210913180222-943fd674d43e // indirect
+	golang.org/x/oauth2 v0.0.0-20210819190943-2bc19b11175f // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20210903162649-d08c68adba83 // indirect
+	google.golang.org/grpc v1.40.0 // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/gorp.v1 v1.7.2 // indirect
+	gopkg.in/ini.v1 v1.63.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/internal/util/get_project_root_dir.go
+++ b/internal/util/get_project_root_dir.go
@@ -1,4 +1,4 @@
-// +build !scripts
+//go:build !scripts
 
 package util
 

--- a/internal/util/get_project_root_dir_scripts.go
+++ b/internal/util/get_project_root_dir_scripts.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package util
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -20,9 +20,9 @@ The `gsdev` cli util executes this `scripts/main.go` file here and also describe
 
 `func`s may define shared logic used in `/scripts/internal/**/*.go`, the actual usable commands are defined within `/scripts/internal`.
 
-### `// +build scripts`
+### `//go:build scripts`
 
-Any `*.go` file in all subdirectories of `/scripts/**` should specify `// +build scripts` to signal that those files are not part of of our final product. To execute any script that has this build tag, you need to specify `-tags scripts`, otherwise you will run into an error like the following (also see our `Makefile` for a reference):
+Any `*.go` file in all subdirectories of `/scripts/**` should specify `//go:build scripts` to signal that those files are not part of of our final product. To execute any script that has this build tag, you need to specify `-tags scripts`, otherwise you will run into an error like the following (also see our `Makefile` for a reference):
 
 ```bash
 # Works

--- a/scripts/cmd/handlers.go
+++ b/scripts/cmd/handlers.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package cmd
 

--- a/scripts/cmd/handlers_check.go
+++ b/scripts/cmd/handlers_check.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package cmd
 

--- a/scripts/cmd/handlers_gen.go
+++ b/scripts/cmd/handlers_gen.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package cmd
 

--- a/scripts/cmd/modulename.go
+++ b/scripts/cmd/modulename.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package cmd
 

--- a/scripts/cmd/root.go
+++ b/scripts/cmd/root.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package cmd
 

--- a/scripts/cmd/scaffold.go
+++ b/scripts/cmd/scaffold.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package cmd
 

--- a/scripts/internal/handlers/check.go
+++ b/scripts/internal/handlers/check.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 // This program checks /internal/api/handlers.go and /internal/types/spec_handlers.go
 // It can be invoked by running go run -tags scripts scripts/handlers/check_handlers.go

--- a/scripts/internal/handlers/gen.go
+++ b/scripts/internal/handlers/gen.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 // This program generates /internal/api/handlers.go.
 // It can be invoked by running go run -tags scripts scripts/handlers/gen_handlers.go

--- a/scripts/internal/scaffold/scaffold.go
+++ b/scripts/internal/scaffold/scaffold.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package scaffold
 

--- a/scripts/internal/scaffold/scaffold_test.go
+++ b/scripts/internal/scaffold/scaffold_test.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package scaffold_test
 

--- a/scripts/internal/scaffold/templates.go
+++ b/scripts/internal/scaffold/templates.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package scaffold
 

--- a/scripts/internal/util/get_module_name.go
+++ b/scripts/internal/util/get_module_name.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package util
 

--- a/scripts/internal/util/get_project_root_dir.go
+++ b/scripts/internal/util/get_project_root_dir.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package util
 

--- a/scripts/main.go
+++ b/scripts/main.go
@@ -1,4 +1,4 @@
-// +build scripts
+//go:build scripts
 
 package main
 

--- a/tools.go
+++ b/tools.go
@@ -1,4 +1,4 @@
-// +build tools
+//go:build tools
 
 package tools
 


### PR DESCRIPTION
- **BREAKING** Upgrades to [Go 1.17.1](https://golang.org/doc/go1.17) `golang:1.17.1-buster`
  - Switch to `//go:build <tag>` from `// +build <tag>`.
  - Migrates `go.mod` via `go mod tidy -go=1.17` (pruned module graphs).