### PR TITLE
update Makefile to show better help message

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -398,10 +398,9 @@ get-go-ldflags: ##- (opt) Prints used -ldflags as evaluated in Makefile used in 
 
 # https://gist.github.com/prwhite/8168133 - based on comment from @m000
 help: ##- Show common make targets.
-	@echo "usage: make <target>"
+	@echo "usage: make \033[36m<target>\033[0m"
 	@echo "note: use 'make help-all' to see all make targets."
-	@echo ""
-	@sed -e '/#\{2\}-/!d; s/\\$$//; s/:[^#\t]*/@/; s/#\{2\}- *//' $(MAKEFILE_LIST) | grep --invert "(opt)" | sort | column -t -s '@'
+	@awk 'BEGIN {FS = ":.*#\#-"; } /^[a-zA-Z_-]+:.*?/ { printf "  \033[36m%-40s\033[0m %s\n", $$1, $$2 } /^# --- / { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 help-all: ##- Show all make targets.
 	@echo "usage: make <target>"


### PR DESCRIPTION
changes:
group targets and colorful 

screen shot:
![iShot_2023-06-21_10 57 59](https://github.com/allaboutapps/go-starter/assets/71397/c18a703d-5a0b-4f5c-9b5e-0685feba9da8)

issues: 
no idea how to strip the "Make variables" and "Special targets", maybe using different group mark for these special groups

discussion:
Why not setting the default goal to `help` (using .DEFAULT_GOAL:=help)? So that just running `make` as a quick start point to display help message. I use this convention in all my projects BTW.