### PR TITLE
Update build-test.yml

### DIFF
--- a/.changes-go-starter/unreleased/Changed-20250404-064611.yaml
+++ b/.changes-go-starter/unreleased/Changed-20250404-064611.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Bump Github action workflow `actions/checkout` from `v2.3.4` to `v4`
+time: 2025-04-04T06:46:11.690151042Z

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -34,7 +34,7 @@ jobs:
       mailhog:
         image: mailhog/mailhog
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - name: docker build (target builder)
         run: DOCKER_BUILDKIT=1 docker build --target builder --file Dockerfile --tag allaboutapps.dev/aw/go-starter:builder-${GITHUB_SHA} .
       - name: docker build (target app)
@@ -91,8 +91,8 @@ jobs:
         run: docker rm builder
   swagger-codegen-cli:
     runs-on: ubuntu-latest
-    container: swaggerapi/swagger-codegen-cli
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - name: run the main swagger.yml validation
-        run: java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar validate -i ./api/swagger.yml
+        run: |
+          docker run --rm -v ${{ github.workspace }}:/local swaggerapi/swagger-codegen-cli validate -i /local/api/swagger.yml


### PR DESCRIPTION
fix github action error in swagger-codegen-cli:
"Error relocating /__e/node20_alpine/bin/node: secure_getenv: symbol not found"